### PR TITLE
Implement product listing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Routes, Route, Navigate } from 'react-router-dom'
 import Login from './pages/Login'
 import Products from './pages/Products'
+import ProductList from './pages/ProductList'
 import './App.css'
 
 function PrivateRoute({ children }: { children: React.ReactElement }) {
@@ -18,6 +19,14 @@ export default function App() {
         element={
           <PrivateRoute>
             <Products />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/list"
+        element={
+          <PrivateRoute>
+            <ProductList />
           </PrivateRoute>
         }
       />

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+import { Separator } from '@/components/ui/separator'
+
+interface Product {
+  OwnerId: string
+  ProductName: string
+  Image: string
+  Price: string
+  Description: string
+  id: string
+  WhatsappMessage: string
+  Active: string
+}
+
+export default function ProductList() {
+  const [products, setProducts] = useState<Product[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(
+          'https://webhook-workflows.baiosystems.com.br/webhook/produtos'
+        )
+        if (!res.ok) {
+          throw new Error(res.statusText)
+        }
+        const data = (await res.json()) as Product[]
+        setProducts(data)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    load()
+  }, [])
+
+  if (loading) {
+    return <p>Carregando...</p>
+  }
+
+  return (
+    <div className="products-container">
+      <h1>Produtos</h1>
+      <Separator className="my-4" />
+      <ul className="product-list">
+        {products.map((p) => (
+          <li key={p.id} className="product-item">
+            <img src={p.Image} alt={p.ProductName} />
+            <div>
+              <strong>{p.ProductName}</strong>
+              <p>{p.Description}</p>
+              <span>R$ {p.Price}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create product listing page with data loaded from a webhook
- add a route `/list` that renders the listing page

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68547821688c832b8660ddb4d29717f1