### PR TITLE
Add API service and integrate PUT update

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,28 @@
+export interface Product {
+  OwnerId: string
+  ProductName: string
+  Image: string
+  Price: string
+  Description: string
+  id: string
+  WhatsappMessage: string
+  Active: string
+}
+
+const API_BASE = 'https://webhook-workflows.baiosystems.com.br/webhook'
+
+export async function getProducts(): Promise<Product[]> {
+  const res = await fetch(`${API_BASE}/produtos`)
+  if (!res.ok) throw new Error(res.statusText)
+  return res.json()
+}
+
+export async function updateProduct(product: Product) {
+  const res = await fetch(`${API_BASE}/produtos/${product.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(product),
+  })
+  if (!res.ok) throw new Error(res.statusText)
+  return res.json()
+}

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -11,17 +11,8 @@ import {
   SheetFooter,
   SheetClose,
 } from '@/components/ui/sheet'
-
-interface Product {
-  OwnerId: string
-  ProductName: string
-  Image: string
-  Price: string
-  Description: string
-  id: string
-  WhatsappMessage: string
-  Active: string
-}
+import type { Product } from '@/lib/api'
+import { getProducts, updateProduct } from '@/lib/api'
 
 export default function ProductList() {
   const [products, setProducts] = useState<Product[]>([])
@@ -32,13 +23,7 @@ export default function ProductList() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch(
-          'https://webhook-workflows.baiosystems.com.br/webhook/produtos'
-        )
-        if (!res.ok) {
-          throw new Error(res.statusText)
-        }
-        const data = (await res.json()) as Product[]
+        const data = await getProducts()
         setProducts(data)
       } catch (err) {
         console.error(err)
@@ -62,13 +47,19 @@ export default function ProductList() {
     setEditing({ ...editing, [e.target.name]: e.target.value })
   }
 
-  function saveEdit(e: React.FormEvent) {
+  async function saveEdit(e: React.FormEvent) {
     e.preventDefault()
     if (!editing) return
-    setProducts((prev) =>
-      prev.map((item) => (item.id === editing.id ? editing : item))
-    )
-    setOpen(false)
+    try {
+      await updateProduct(editing)
+      setProducts((prev) =>
+        prev.map((item) => (item.id === editing.id ? editing : item))
+      )
+      setOpen(false)
+    } catch (err) {
+      console.error(err)
+      alert('Erro ao atualizar produto')
+    }
   }
 
   if (loading) {


### PR DESCRIPTION
## Summary
- create API helper with getProducts and updateProduct
- load products using the helper
- send PUT request when saving edited product

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68554b7d955c832ba307c107eaca6f61