### PR TITLE
Atualizar endpoints do catálogo

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,16 +9,15 @@ export interface Product {
   Active: string
 }
 
-const API_BASE = 'https://webhook-workflows.baiosystems.com.br/webhook'
-
-export async function getProducts(): Promise<Product[]> {
-  const res = await fetch(`${API_BASE}/produtos`)
+const API_BASE = 'https://catalogo-virtual-server.onrender.com'
+export async function getProducts(query: string): Promise<Product[]> {
+  const res = await fetch(`${API_BASE}/api/produto/query/${encodeURIComponent(query)}`)
   if (!res.ok) throw new Error(res.statusText)
   return res.json()
 }
 
 export async function updateProduct(product: Product) {
-  const res = await fetch(`${API_BASE}/produtos/${product.id}`, {
+  const res = await fetch(`${API_BASE}/api/produto/${product.id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(product),

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -23,7 +23,7 @@ export default function ProductList() {
   useEffect(() => {
     async function load() {
       try {
-        const data = await getProducts()
+        const data = await getProducts('all')
         setProducts(data)
       } catch (err) {
         console.error(err)


### PR DESCRIPTION
## Summary
- update API base URL to the new server
- adjust `getProducts` to accept a query parameter
- update `ProductList` to use the new query-based endpoint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856c297af7c832bbea87a09bd6d8261