### PR TITLE
Add login inputs storage

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -19,6 +19,7 @@ export default function Login() {
       const data = await login(user, email, pass)
       localStorage.setItem('logged', 'true')
       localStorage.setItem('userData', JSON.stringify(data))
+      localStorage.setItem('loginData', JSON.stringify({ user, email, pass }))
       navigate('/products')
     } catch (err) {
       setError((err as Error).message || 'Credenciais inválidas')


### PR DESCRIPTION
## Summary
- store input credentials on successful login

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856eb03c504832ba1f1677aaa32453e