### PR TITLE
Implement home screen and company parameter usage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from 'react-router-dom'
 import Login from './pages/Login'
 import Products from './pages/Products'
 import ProductList from './pages/ProductList'
+import Home from './pages/Home'
 import './App.css'
 
 function PrivateRoute({ children }: { children: React.ReactElement }) {
@@ -14,6 +15,14 @@ export default function App() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route
+        path="/home"
+        element={
+          <PrivateRoute>
+            <Home />
+          </PrivateRoute>
+        }
+      />
       <Route
         path="/products"
         element={

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom'
+import { Separator } from '@/components/ui/separator'
+
+export default function Home() {
+  return (
+    <div className="products-container">
+      <h1>Menu</h1>
+      <Separator className="my-4" />
+      <nav className="flex flex-col gap-4 items-start">
+        <Link to="/products">Cadastro de Produtos</Link>
+        <Link to="/list">Lista de Produtos</Link>
+      </nav>
+    </div>
+  )
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -20,7 +20,7 @@ export default function Login() {
       localStorage.setItem('logged', 'true')
       localStorage.setItem('userData', JSON.stringify(data))
       localStorage.setItem('loginData', JSON.stringify({ user, email, pass }))
-      navigate('/products')
+      navigate('/home')
     } catch (err) {
       setError((err as Error).message || 'Credenciais inválidas')
     }

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -35,7 +35,9 @@ export default function ProductList() {
   useEffect(() => {
     async function load() {
       try {
-        const data = await getProducts('all')
+        const company = JSON.parse(localStorage.getItem('userData') || '{}').Company
+        const query = company || 'all'
+        const data = await getProducts(query)
         setProducts(data)
       } catch (err) {
         console.error(err)


### PR DESCRIPTION
## Summary
- add a new Home page with links to existing pages
- redirect to Home after login
- include Home in routing
- use stored `Company` in ProductList request

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68578e123b5c832b99cf895eaefcd4d3