### PR TITLE
Fix product list editing and mobile layout

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed z-50 grid w-full max-w-lg scale-100 gap-4 border bg-background p-6 shadow-lg",
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 scale-100 gap-4 border bg-background p-6 shadow-lg",
         className
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -139,6 +139,18 @@ button:focus-visible {
   object-fit: cover;
 }
 
+@media (max-width: 600px) {
+  .product-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .product-item img {
+    width: 100%;
+    height: auto;
+  }
+}
+
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -144,37 +144,37 @@ export default function ProductList() {
           {editing && (
             <form onSubmit={saveEdit} className="product-form mt-4">
               <Input
-                name="OwnerId"
+                name="ownerId"
                 placeholder="Owner"
                 value={editing.ownerId}
                 onChange={handleChange}
               />
               <Input
-                name="ProductName"
+                name="name"
                 placeholder="Nome"
                 value={editing.name}
                 onChange={handleChange}
               />
               <Input
-                name="Image"
+                name="image"
                 placeholder="Imagem"
                 value={editing.image}
                 onChange={handleChange}
               />
               <Input
-                name="Price"
+                name="price"
                 placeholder="Preço"
                 value={editing.price}
                 onChange={handleChange}
               />
               <Textarea
-                name="Description"
+                name="description"
                 placeholder="Descrição"
                 value={editing.description}
                 onChange={handleChange}
               />
               <Input
-                name="WhatsappMessage"
+                name="whatsappMessage"
                 placeholder="Mensagem WhatsApp"
                 value={editing.whatsappMessage}
                 onChange={handleChange}


### PR DESCRIPTION
## Summary
- center alert dialog box
- fix field names in `ProductList` edit form
- make product list responsive for small screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68583b107fa4832bb7116f0d48344338