### PR TITLE
Ajustar centralização e alert

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -69,7 +69,13 @@ const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
 SheetHeader.displayName = "SheetHeader"
 
 const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+  <div
+    className={cn(
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
 )
 SheetFooter.displayName = "SheetFooter"
 

--- a/src/index.css
+++ b/src/index.css
@@ -117,6 +117,8 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  align-items: center;
+  text-align: center;
 }
 
 .product-list {
@@ -125,12 +127,14 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  align-items: center;
 }
 
 .product-item {
   display: flex;
   gap: 1rem;
   align-items: center;
+  text-align: center;
 }
 
 .product-item img {
@@ -142,7 +146,7 @@ button:focus-visible {
 @media (max-width: 600px) {
   .product-item {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
   }
 
   .product-item img {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -37,7 +37,7 @@ export async function updateProduct(product: Product) {
     OwnerId: product.ownerId || '',
     Name: product.name,
     Image: product.image,
-    Price: Number(product.price),
+    Price: Number(product.price.replace(',', '.')),
     Description: product.description,
     id: product.id,
     WhatsappMessage: product.whatsappMessage,

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -76,17 +76,19 @@ export default function ProductList() {
         prev.map((item) => (item.id === editing.id ? editing : item))
       )
       setOpen(false)
+      setErrorMsg(null)
     } catch (err) {
       console.error(err)
       setOpen(false)
       setErrorMsg('Erro ao atualizar produto')
     }
   }
-
+  
   async function remove(id: string) {
     try {
       await deleteProduct(id)
       setProducts((prev) => prev.filter((item) => item.id !== id))
+      setErrorMsg(null)
     } catch (err) {
       console.error(err)
       setErrorMsg('Erro ao remover produto')
@@ -156,7 +158,8 @@ export default function ProductList() {
                 name="ownerId"
                 placeholder="Owner"
                 value={editing.ownerId}
-                onChange={handleChange}
+                disabled
+                style={{ border: 'none' }}
               />
               <Input
                 name="name"

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/sheet'
 import type { Product, ProductResponse } from '@/lib/api'
 import { getProducts, updateProduct, deleteProduct } from '@/lib/api'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
   AlertDialog,
   AlertDialogTrigger,
@@ -31,6 +32,7 @@ export default function ProductList() {
   const [loading, setLoading] = useState(true)
   const [open, setOpen] = useState(false)
   const [editing, setEditing] = useState<Product | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
 
   useEffect(() => {
     async function load() {
@@ -76,7 +78,7 @@ export default function ProductList() {
       setOpen(false)
     } catch (err) {
       console.error(err)
-      alert('Erro ao atualizar produto')
+      setErrorMsg('Erro ao atualizar produto')
     }
   }
 
@@ -86,7 +88,7 @@ export default function ProductList() {
       setProducts((prev) => prev.filter((item) => item.id !== id))
     } catch (err) {
       console.error(err)
-      alert('Erro ao remover produto')
+      setErrorMsg('Erro ao remover produto')
     }
   }
 
@@ -98,6 +100,12 @@ export default function ProductList() {
     <div className="products-container">
         <DrawerMenu />
       <h1>Produtos</h1>
+      {errorMsg && (
+        <Alert className="my-4">
+          <AlertTitle>Erro</AlertTitle>
+          <AlertDescription>{errorMsg}</AlertDescription>
+        </Alert>
+      )}
       <Separator className="my-4" />
       <ul className="product-list" key={products.length}>
         {products?.map((p: Product) => (

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -78,6 +78,7 @@ export default function ProductList() {
       setOpen(false)
     } catch (err) {
       console.error(err)
+      setOpen(false)
       setErrorMsg('Erro ao atualizar produto')
     }
   }


### PR DESCRIPTION
## Summary
- centralizar itens da lista e do formulário
- aplicar espaçamento nos botões do `SheetFooter`
- utilizar componente `Alert` para erros de edição ou remoção

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68583edcd1d4832ba38b455d8896e524