### PR TITLE
Implement image upload for editing products

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -51,7 +51,7 @@ export async function updateProduct(product: Product) {
     OwnerId: product.ownerId || '',
     Name: product.name,
     Image: product.image,
-    Price: Number(product.price.replace(',', '.')),
+    Price:  Number(typeof product.price == typeof "" ? product.price?.replace(',', '.'): product.price) ,
     Description: product.description,
     id: product.id,
     WhatsappMessage: product.whatsappMessage,

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -67,6 +67,37 @@ export default function ProductList() {
     setEditing({ ...editing, [e.target.name]: e.target.value })
   }
 
+  function handleImageChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file || !editing) return
+
+    const reader = new FileReader()
+    reader.onload = () => {
+      const img = new Image()
+      img.onload = () => {
+        const canvas = document.createElement('canvas')
+        const MAX_DIMENSION = 400
+        let { width, height } = img
+        if (width > height && width > MAX_DIMENSION) {
+          height = (height * MAX_DIMENSION) / width
+          width = MAX_DIMENSION
+        } else if (height > MAX_DIMENSION) {
+          width = (width * MAX_DIMENSION) / height
+          height = MAX_DIMENSION
+        }
+        canvas.width = width
+        canvas.height = height
+        const ctx = canvas.getContext('2d')
+        if (!ctx) return
+        ctx.drawImage(img, 0, 0, width, height)
+        const compressed = canvas.toDataURL('image/jpeg', 0.7)
+        setEditing((prev) => (prev ? { ...prev, image: compressed } : null))
+      }
+      img.src = reader.result as string
+    }
+    reader.readAsDataURL(file)
+  }
+
   async function saveEdit(e: React.FormEvent) {
     e.preventDefault()
     if (!editing) return
@@ -167,12 +198,14 @@ export default function ProductList() {
                 value={editing.name}
                 onChange={handleChange}
               />
-              <Input
-                name="image"
-                placeholder="Imagem"
-                value={editing.image}
-                onChange={handleChange}
-              />
+              <Input type="file" name="image" onChange={handleImageChange} />
+              {editing.image && (
+                <img
+                  src={editing.image}
+                  alt="Preview"
+                  style={{ width: '100px', height: '100px', objectFit: 'cover' }}
+                />
+              )}
               <Input
                 name="price"
                 placeholder="Preço"

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -15,7 +15,7 @@ export default function Products() {
   const company = JSON.parse(localStorage.getItem('userData') || '{}').company
 
   const [form, setForm] = useState<Omit<Product, 'id'>>({
-    ownerId: '',
+    ownerId: company || '',
     name: '',
     image: '',
     price: '',


### PR DESCRIPTION
## Summary
- allow uploading an image when editing a product
- show a preview of the uploaded image

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685938ce9ddc832b9387d4617ed4bac5